### PR TITLE
Fix: SAML - group_mapping(s), new issuer_url attribute support

### DIFF
--- a/examples/resources/wiz_saml_idp/resource.tf
+++ b/examples/resources/wiz_saml_idp/resource.tf
@@ -2,9 +2,17 @@ resource "wiz_saml_idp" "test" {
   name                         = "Ping"
   login_url                    = "https://ping.example.com/idp/SSO.saml2"
   logout_url                   = "https://ping.example.com/idp/SLO.saml2"
-  use_provider_managed_roles   = false
+  use_provider_managed_roles   = true
   merge_groups_mapping_by_role = false
-  certificate                  = <<EOT
+  allow_manual_role_override   = false
+
+  group_mapping {
+    provider_group_id = "AAD-GROUP-ADMINS"
+    role              = "PROJECT_ADMIN"
+    projects          = ["54000827-d3ff-5745-887b-417beb977ff9"]
+  }
+
+  certificate = <<EOT
 -----BEGIN CERTIFICATE-----
 MIIFpzCCA4+gAwIBAgIJAKY0mQyPWs1eMA0GCSqGSIb3DQEBCwUAMGoxCzAJBgNV
 BAYTAlVTMRAwDgYDVQQIDAdOb3doZXJlMRwwGgYDVQQHDBNOb3RoaW5nIHRvIHNl

--- a/internal/vendor/wiz.go
+++ b/internal/vendor/wiz.go
@@ -180,6 +180,7 @@ type UpdateSAMLIdentityProviderPatch struct {
 	EntityID                 string                        `json:"entityID,omitempty"`
 	LoginURL                 string                        `json:"loginURL,omitempty"`
 	LogoutURL                string                        `json:"logoutURL,omitempty"`
+	IssuerURL                string                        `json:"issuerURL,omitempty"`
 	UseProviderManagedRoles  *bool                         `json:"useProviderManagedRoles,omitempty"`
 	AllowManualRoleOverride  *bool                         `json:"allowManualRoleOverride,omitempty"`
 	Certificate              string                        `json:"certificate,omitempty"`
@@ -206,6 +207,7 @@ type CreateSAMLIdentityProviderInput struct {
 	EntityID                 string                         `json:"entityID,omitempty"`
 	LoginURL                 string                         `json:"loginURL"`
 	LogoutURL                string                         `json:"logoutURL,omitempty"`
+	IssuerURL                string                         `json:"issuerURL,omitempty"`
 	UseProviderManagedRoles  bool                           `json:"useProviderManagedRoles"`
 	AllowManualRoleOverride  *bool                          `json:"allowManualRoleOverride,omitempty"`
 	Certificate              string                         `json:"certificate"`


### PR DESCRIPTION
### Background 

As mentioned in [this](https://github.com/AxtonGrams/terraform-provider-wiz/issues/39) issue. The Wiz API is seemingly particular around which combinations of values are allowed as `input` when calling a mutation against `UpdateSAMLIdentityProvider`. As described in the issue, this is experienced when trying to make changes (`patch`) existing `group_mappings` With the current stable release, it is also not possible for example, to update or patch values like `login_url`.  

The ability to set the `issuer_url` was also not yet implemented.

### Proposed Changes
- Allow the setting of the `issuer_url` so that it does not automatically get set to the `login` url but can also support specific non URL values such as `URIs`/`ARNs`
- Updated example HCL file for `wiz_saml_idp`
- Updated `wiz_saml_idp` schema attribute dependencies
- Set `domains` attribute to optional as it should not be required and is currently not being set at create or update time
- Setting the additional necessary fields for the API request when any change is made to `group_mapping `