### PR TITLE
New Feature: Add cloud account links support for wiz_project

### DIFF
--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -13,6 +13,17 @@ Projects let you group your cloud resources according to their users and/or purp
 ## Example Usage
 
 ```terraform
+# A simple example
+
+resource "wiz_project" "test" {
+  name        = "Test App"
+  description = "My project description"
+  risk_profile {
+    business_impact = "MBI"
+  }
+  business_unit = "Technology"
+}
+
 # This resource contains multiple organization links, one with tags and another without
 
 resource "wiz_project" "test" {
@@ -42,7 +53,7 @@ resource "wiz_project" "test" {
   }
 }
 
-# A simple example
+# This resource contains a single cloud account link, with tag
 
 resource "wiz_project" "test" {
   name        = "Test App"
@@ -50,7 +61,19 @@ resource "wiz_project" "test" {
   risk_profile {
     business_impact = "MBI"
   }
-  business_unit = "Technology"
+  business_unit = data.insight_organization.aws.description
+
+  # Below also supports a dynamic block which chould iterate over
+  # map attributes of the wiz_cloud_accounts data source
+  cloud_account_link {
+    cloud_account_id = "3225def3-0e0e-5cb8-955a-3583f696f77f"
+    environment      = "PRODUCTION"
+    resource_tags {
+      key   = "created_by"
+      value = "terraform"
+    }
+  }
+
 }
 ```
 
@@ -66,7 +89,8 @@ resource "wiz_project" "test" {
 - `archived` (Boolean) Whether the project is archived/inactive
     - Defaults to `false`.
 - `business_unit` (String) The business unit to which the project belongs.
-- `cloud_organization_link` (Block Set) Associate the project with the resources and subscriptions to organize all the resources, issues, and findings within this project. (see [below for nested schema](#nestedblock--cloud_organization_link))
+- `cloud_account_link` (Block Set) Associate the project directly with a cloud account by wiz identifier UID to organize all the subscription resources, issues, and findings within this project. (see [below for nested schema](#nestedblock--cloud_account_link))
+- `cloud_organization_link` (Block Set) Associate the project with an organizational link to organize all the subscription resources, issues, and findings within this project. (see [below for nested schema](#nestedblock--cloud_organization_link))
 - `description` (String) The project description.
 - `risk_profile` (Block List, Max: 1) Contains risk profile related properties for the project (see [below for nested schema](#nestedblock--risk_profile))
 
@@ -99,6 +123,36 @@ Optional:
 
 <a id="nestedblock--cloud_organization_link--resource_tags"></a>
 ### Nested Schema for `cloud_organization_link.resource_tags`
+
+Required:
+
+- `key` (String)
+- `value` (String)
+
+<a id="nestedblock--cloud_account_link"></a>
+### Nested Schema for `cloud_account_link`
+
+Required:
+
+- `cloud_account_id` (String) The Wiz internal identifier for the Subscription.
+
+Optional:
+
+- `environment` (String) The environment.
+    - Allowed values: 
+        - PRODUCTION
+        - STAGING
+        - DEVELOPMENT
+        - TESTING
+        - OTHER
+
+    - Defaults to `PRODUCTION`.
+- `resource_tags` (Block Set) Provide a key and value pair for filtering resources. `shared` must be true to define resource_tags. (see [below for nested schema](#nestedblock--cloud_account_link--resource_tags))
+- `shared` (Boolean) Subscriptions that host a few projects can be marked as ‘shared subscriptions’ and resources can be filtered by tags.
+    - Defaults to `true`.
+
+<a id="nestedblock--cloud_account_link--resource_tags"></a>
+### Nested Schema for `cloud_account_link.resource_tags`
 
 Required:
 

--- a/examples/resources/wiz_project/resource.tf
+++ b/examples/resources/wiz_project/resource.tf
@@ -1,5 +1,15 @@
-# This resource contains multiple organization links, one with tags and another without
+# A simple example
+resource "wiz_project" "test" {
+  name        = "Test App"
+  description = "My project description"
+  risk_profile {
+    business_impact = "MBI"
+  }
+  business_unit = "Technology"
+}
 
+
+# This resource contains multiple organization links, one with tags and another without
 resource "wiz_project" "test" {
   name        = "Test App"
   description = "My project description"
@@ -27,13 +37,24 @@ resource "wiz_project" "test" {
   }
 }
 
-# A simple example
-
+# This resource contains a single cloud account link, with tag
 resource "wiz_project" "test" {
   name        = "Test App"
   description = "My project description"
   risk_profile {
     business_impact = "MBI"
   }
-  business_unit = "Technology"
+  business_unit = data.insight_organization.aws.description
+
+  # Below also supports a dynamic block which chould iterate over
+  # map attributes of the `wiz_cloud_accounts` data source
+  cloud_account_link {
+    cloud_account_id = "3225def3-0e0e-5cb8-955a-3583f696f778"
+    environment      = "PRODUCTION"
+    resource_tags {
+      key   = "created_by"
+      value = "terraform"
+    }
+  }
+
 }

--- a/internal/provider/resource_project_test.go
+++ b/internal/provider/resource_project_test.go
@@ -145,6 +145,159 @@ func TestFlattenRiskProfileDefaults(t *testing.T) {
 	}
 }
 
+func TestFlattenCloudAccountLinksWithTags(t *testing.T) {
+	ctx := context.Background()
+
+	expected := []interface{}{
+		map[string]interface{}{
+			"cloud_account_id": "3225def3-0e0e-5cb8-955a-3583f696f77f",
+			"shared":           true,
+			"environment":      "PRODUCTION",
+			"resource_tags": []interface{}{
+				map[string]interface{}{
+					"key":   "k1",
+					"value": "v1",
+				},
+				map[string]interface{}{
+					"key":   "k2",
+					"value": "v2",
+				},
+			},
+		},
+	}
+
+	var projectCloudAccountLink1 = &vendor.ProjectCloudAccountLink{
+		CloudAccount: vendor.CloudAccount{
+			ID: "3225def3-0e0e-5cb8-955a-3583f696f77f",
+		},
+		Shared:      true,
+		Environment: "PRODUCTION",
+		ResourceTags: []*vendor.ResourceTag{
+			{
+				Key:   "k1",
+				Value: "v1",
+			},
+			{
+				Key:   "k2",
+				Value: "v2",
+			},
+		},
+	}
+
+	expanded := []*vendor.ProjectCloudAccountLink{}
+	expanded = append(expanded, projectCloudAccountLink1)
+
+	cloudAccountLinks := flattenCloudAccountLinks(ctx, expanded)
+
+	if !reflect.DeepEqual(cloudAccountLinks, expected) {
+		t.Fatalf(
+			"Got:\n\n%#v\n\nExpected:\n\n%#v\n",
+			cloudAccountLinks,
+			expected,
+		)
+	}
+}
+
+func TestFlattenCloudAccountLinksNoTags(t *testing.T) {
+	ctx := context.Background()
+
+	expected := []interface{}{
+		map[string]interface{}{
+			"cloud_account_id": "3225def3-0e0e-5cb8-955a-3583f696f77f",
+			"shared":           true,
+			"environment":      "PRODUCTION",
+			"resource_tags":    []interface{}{},
+		},
+	}
+
+	var projectCloudAccountLink1 = &vendor.ProjectCloudAccountLink{
+		CloudAccount: vendor.CloudAccount{
+			ID: "3225def3-0e0e-5cb8-955a-3583f696f77f",
+		},
+		Shared:       true,
+		Environment:  "PRODUCTION",
+		ResourceTags: []*vendor.ResourceTag{},
+	}
+
+	expanded := []*vendor.ProjectCloudAccountLink{}
+	expanded = append(expanded, projectCloudAccountLink1)
+
+	cloudAccountLinks := flattenCloudAccountLinks(ctx, expanded)
+
+	if !reflect.DeepEqual(cloudAccountLinks, expected) {
+		t.Fatalf(
+			"Got:\n\n%#v\n\nExpected:\n\n%#v\n",
+			cloudAccountLinks,
+			expected,
+		)
+	}
+}
+
+func TestGetCloudAccountLinksVar(t *testing.T) {
+	ctx := context.Background()
+
+	var expectedAcclink1 = &vendor.ProjectCloudAccountLinkInput{
+		ID:          "3225def3-0e0e-5cb8-955a-3583f696f77f",
+		Environment: "PRODUCTION",
+		ResourceTags: []*vendor.ResourceTag{
+			{
+				Key:   "7982c5c6-1c66-435c-a509-68fae7718bd8",
+				Value: "fbf63c90-67ed-4198-af07-05ee17a58c1d",
+			},
+		},
+		Shared: true,
+	}
+
+	var expectedAcclink2 = &vendor.ProjectCloudAccountLinkInput{
+		ID:          "d8181cf9-38bb-486c-8278-f95f416afb3c",
+		Environment: "PRODUCTION",
+		Shared:      false,
+	}
+
+	var expected = []*vendor.ProjectCloudAccountLinkInput{}
+	expected = append(expected, expectedAcclink1)
+	expected = append(expected, expectedAcclink2)
+
+	d := schema.TestResourceDataRaw(
+		t,
+		resourceWizProject().Schema,
+		map[string]interface{}{
+			"name": "my project",
+			"cloud_account_link": []interface{}{
+				map[string]interface{}{
+					"cloud_account_id": "3225def3-0e0e-5cb8-955a-3583f696f77f",
+					"environment":      "PRODUCTION",
+					"shared":           true,
+					"resource_tags": []interface{}{
+						map[string]interface{}{
+							"key":   "7982c5c6-1c66-435c-a509-68fae7718bd8",
+							"value": "fbf63c90-67ed-4198-af07-05ee17a58c1d",
+						},
+					},
+				},
+				map[string]interface{}{
+					"cloud_account_id": "d8181cf9-38bb-486c-8278-f95f416afb3c",
+					"environment":      "PRODUCTION",
+					"shared":           false,
+				},
+			},
+		},
+	)
+
+	accLink := getCloudAccountLinksVar(ctx, d)
+
+	sort.SliceStable(expected, func(i, j int) bool { return expected[i].ID < expected[j].ID })
+	sort.SliceStable(accLink, func(i, j int) bool { return accLink[i].ID < accLink[j].ID })
+
+	if !reflect.DeepEqual(expected, accLink) {
+		t.Fatalf(
+			"Got:\n\n%#v\n\nExpected:\n\n%#v\n",
+			utils.PrettyPrint(accLink),
+			utils.PrettyPrint(expected),
+		)
+	}
+}
+
 func TestFlattenCloudOrganizationLinksWithTags(t *testing.T) {
 	ctx := context.Background()
 

--- a/internal/vendor/wiz.go
+++ b/internal/vendor/wiz.go
@@ -106,6 +106,7 @@ type CreateProjectInput struct {
 	SecurityChampion       []string                             `json:"securityChampions,omitempty"`
 	RiskProfile            ProjectRiskProfileInput              `json:"riskProfile"`
 	CloudOrganizationLinks []*ProjectCloudOrganizationLinkInput `json:"cloudOrganizationLinks,omitempty"`
+	CloudAccountLinks      []*ProjectCloudAccountLinkInput      `json:"cloudAccountLinks,omitempty"`
 }
 
 // Environment enum
@@ -123,6 +124,13 @@ type ProjectCloudOrganizationLinkInput struct {
 	Environment       string         `json:"environment"` // enum Environment
 	ResourceTags      []*ResourceTag `json:"resourceTags"`
 	Shared            bool           `json:"shared"`
+}
+
+type ProjectCloudAccountLinkInput struct {
+	ID           string         `json:"cloudAccount"`
+	Environment  string         `json:"environment"` // enum Environment
+	ResourceTags []*ResourceTag `json:"resourceTags"`
+	Shared       bool           `json:"shared"`
 }
 
 // ResourceTag struct
@@ -167,6 +175,7 @@ type UpdateProjectPatch struct {
 	BusinessUnit           string                               `json:"businessUnit,omitempty"`
 	RiskProfile            *ProjectRiskProfileInput             `json:"riskProfile,omitempty"`
 	CloudOrganizationLinks []*ProjectCloudOrganizationLinkInput `json:"cloudOrganizationLinks"`
+	CloudAccountLinks      []*ProjectCloudAccountLinkInput      `json:"cloudAccountLinks"`
 }
 
 // UpdateSAMLIdentityProviderInput struct
@@ -317,11 +326,11 @@ type Project struct {
 
 // ProjectCloudAccountLink struct
 type ProjectCloudAccountLink struct {
-	CloudAccount   CloudAccount  `json:"CloudAccount"`
-	Environment    string        `json:"environment"` // enum Environment
-	ResourceGroups []string      `json:"resourceGroups"`
-	ResourceTags   []ResourceTag `json:"ResourceTag"`
-	Shared         bool          `json:"shared"`
+	CloudAccount   CloudAccount   `json:"CloudAccount"`
+	Environment    string         `json:"environment"` // enum Environment
+	ResourceGroups []string       `json:"resourceGroups"`
+	ResourceTags   []*ResourceTag `json:"ResourceTags"`
+	Shared         bool           `json:"shared"`
 }
 
 // CloudAccountStatus enum


### PR DESCRIPTION
### Background 

Not all plugin consumers would always link to subscriptions an organisation. The lookup of subscriptions by either ID or name is supported by the current datasource but the ability to add the resources to the project by means of a cloud account link was not yet implemented

### Changes
- Introduced `cloud_account_link` to `wiz_project`
- Updated examples and markdown docs
- Created additional tests