### PR TITLE
Fix: SAML group_mapping update issue, and adding issuer_url support

### DIFF
--- a/docs/resources/saml_idp.md
+++ b/docs/resources/saml_idp.md
@@ -17,8 +17,10 @@ resource "wiz_saml_idp" "test" {
   name                         = "Ping"
   login_url                    = "https://ping.example.com/idp/SSO.saml2"
   logout_url                   = "https://ping.example.com/idp/SLO.saml2"
+  issuer_url                   = "urn:mace:incommon:example.edu"
   use_provider_managed_roles   = false
   merge_groups_mapping_by_role = false
+  allow_manual_role_override   = false
   certificate                  = <<EOT
 -----BEGIN CERTIFICATE-----
 MIIFpzCCA4+gAwIBAgIJAKY0mQyPWs1eMA0GCSqGSIb3DQEBCwUAMGoxCzAJBgNV
@@ -66,19 +68,19 @@ EOT
 ### Required
 
 - `certificate` (String) PEM certificate from IdP
-- `domains` (List of String) A list of domains the IdP handles.
+- `domains` (List of String) A list of domains the IdP handles. This block needs to be set to accomodate for update lifecycle operations. If not used then specify an empty list ([])
 - `login_url` (String) IdP Login URL
+- `issuer_url` (String) IdP issuer URL or entity ID. The value needs to match the IdP Issuer value, which *should* generally be a URL but can also be a URI or simple string. If unsure, set to same as login_url.
 - `name` (String) IdP name to display in Wiz.
+- `allow_manual_role_override` (Boolean) Allow manual override for role assignment? This attribute must be set to `true` if `use_provider_managed_roles` attribute is set to `false`. This field needs to be set to accomodate for update lifecycle operations.
+- `merge_groups_mapping_by_role` (Boolean) Manage group mapping by role? This attribute needs to be set to accomodate for update lifecycle operations.
+- `use_provider_managed_roles` (Boolean) Use provider managed roles?
 
 ### Optional
 
-- `allow_manual_role_override` (Boolean) Allow manual override for role assignment? Must be set `true` if `use_provided_roles` is false.
-    - Defaults to `true`.
 - `group_mapping` (Block Set) Group mappings (see [below for nested schema](#nestedblock--group_mapping))
 - `logout_url` (String) IdP Logout URL
-- `merge_groups_mapping_by_role` (Boolean) Manage group mapping by role?
-- `use_provider_managed_roles` (Boolean) Use provider managed roles?
-    - Defaults to `false`.
+
 
 ### Read-Only
 

--- a/examples/resources/wiz_saml_idp/resource.tf
+++ b/examples/resources/wiz_saml_idp/resource.tf
@@ -2,9 +2,17 @@ resource "wiz_saml_idp" "test" {
   name                         = "Ping"
   login_url                    = "https://ping.example.com/idp/SSO.saml2"
   logout_url                   = "https://ping.example.com/idp/SLO.saml2"
-  use_provider_managed_roles   = false
+  use_provider_managed_roles   = true
   merge_groups_mapping_by_role = false
-  certificate                  = <<EOT
+  allow_manual_role_override   = false
+
+  group_mapping {
+    provider_group_id = "AAD-GROUP-ADMINS"
+    role              = "PROJECT_ADMIN"
+    projects          = ["54000827-d3ff-5745-887b-417beb977ff9"]
+  }
+
+  certificate = <<EOT
 -----BEGIN CERTIFICATE-----
 MIIFpzCCA4+gAwIBAgIJAKY0mQyPWs1eMA0GCSqGSIb3DQEBCwUAMGoxCzAJBgNV
 BAYTAlVTMRAwDgYDVQQIDAdOb3doZXJlMRwwGgYDVQQHDBNOb3RoaW5nIHRvIHNl

--- a/internal/vendor/wiz.go
+++ b/internal/vendor/wiz.go
@@ -177,15 +177,15 @@ type UpdateSAMLIdentityProviderInput struct {
 
 // UpdateSAMLIdentityProviderPatch struct -- updates
 type UpdateSAMLIdentityProviderPatch struct {
-	EntityID                 string                        `json:"entityID,omitempty"`
-	LoginURL                 string                        `json:"loginURL,omitempty"`
-	LogoutURL                string                        `json:"logoutURL,omitempty"`
-	UseProviderManagedRoles  *bool                         `json:"useProviderManagedRoles,omitempty"`
-	AllowManualRoleOverride  *bool                         `json:"allowManualRoleOverride,omitempty"`
-	Certificate              string                        `json:"certificate,omitempty"`
-	Domains                  []string                      `json:"domains,omitempty"`
-	GroupMapping             []SAMLGroupMappingUpdateInput `json:"groupMapping,omitempty"`
-	MergeGroupsMappingByRole *bool                         `json:"mergeGroupsMappingByRole,omitempty"`
+	LoginURL                 string                        `json:"loginURL"`
+	LogoutURL                string                        `json:"logoutURL"`
+	IssuerURL                string                        `json:"issuerURL"`
+	UseProviderManagedRoles  *bool                         `json:"useProviderManagedRoles"`
+	AllowManualRoleOverride  *bool                         `json:"allowManualRoleOverride"`
+	Certificate              string                        `json:"certificate"`
+	Domains                  []string                      `json:"domains"`
+	GroupMapping             []SAMLGroupMappingUpdateInput `json:"groupMapping"`
+	MergeGroupsMappingByRole *bool                         `json:"mergeGroupsMappingByRole"`
 }
 
 // UpdateSAMLIdentityProviderPayload struct -- updates
@@ -203,15 +203,15 @@ type SAMLGroupMappingUpdateInput struct {
 // CreateSAMLIdentityProviderInput struct -- updates
 type CreateSAMLIdentityProviderInput struct {
 	Name                     string                         `json:"name"`
-	EntityID                 string                         `json:"entityID,omitempty"`
 	LoginURL                 string                         `json:"loginURL"`
-	LogoutURL                string                         `json:"logoutURL,omitempty"`
+	LogoutURL                string                         `json:"logoutURL"`
+	IssuerURL                string                         `json:"issuerURL"`
 	UseProviderManagedRoles  bool                           `json:"useProviderManagedRoles"`
-	AllowManualRoleOverride  *bool                          `json:"allowManualRoleOverride,omitempty"`
+	AllowManualRoleOverride  *bool                          `json:"allowManualRoleOverride"`
 	Certificate              string                         `json:"certificate"`
 	Domains                  []string                       `json:"domains"`
-	GroupMapping             []*SAMLGroupMappingCreateInput `json:"groupMapping,omitempty"`
-	MergeGroupsMappingByRole *bool                          `json:"mergeGroupsMappingByRole,omitempty"`
+	GroupMapping             []*SAMLGroupMappingCreateInput `json:"groupMapping"`
+	MergeGroupsMappingByRole *bool                          `json:"mergeGroupsMappingByRole"`
 }
 
 // CreateSAMLIdentityProviderPayload struct -- updates
@@ -230,9 +230,9 @@ type SAMLGroupMappingCreateInput struct {
 type SAMLIdentityProvider struct {
 	AllowManualRoleOverride  *bool               `json:"allowManualRoleOverride"`
 	Certificate              string              `json:"certificate"`
-	Domains                  []string            `json:"domains"`
-	EntityID                 string              `json:"entityID,omitempty"`
-	GroupMapping             []*SAMLGroupMapping `json:"groupMapping,omitempty"`
+	Domains                  []*string           `json:"domains"`
+	IssuerURL                string              `json:"issuerURL"`
+	GroupMapping             []*SAMLGroupMapping `json:"groupMapping"`
 	ID                       string              `json:"id"`
 	LoginURL                 string              `json:"loginURL"`
 	LogoutURL                string              `json:"logoutURL"`


### PR DESCRIPTION
### Background 

As mentioned in [this](https://github.com/AxtonGrams/terraform-provider-wiz/issues/39) issue. The Wiz mutation for  `UpdateSAMLIdentityProvider` requires all fields, once set, the key needs to be present in subsequent requests, i.e. `update`. As described in the issue, this is experienced when trying to make changes (`patch`) existing `group_mappings` With the current stable release, it is also not possible for example, to update or patch values like `login_url`.  

The ability to set the `issuer_url` was also not yet implemented.

### Proposed Changes
- Allow the setting of the `issuer_url` so that it does not automatically get set to the `login` url but can also support specific non URL values such as `URIs`/`ARNs`
- Updated example HCL file for `wiz_saml_idp`
- Updated `wiz_saml_idp` schema attribute dependencies
- Marked required fields