### PR TITLE
wiz_kubernetes_clusters name parameter description correction

### DIFF
--- a/internal/provider/data_source_kubernetes_clusters.go
+++ b/internal/provider/data_source_kubernetes_clusters.go
@@ -101,7 +101,7 @@ func dataSourceWizKubernetesClusters() *schema.Resource {
 						"name": {
 							Type:        schema.TypeString,
 							Optional:    true,
-							Description: "Internal Wiz ID of Kubernetes Cluster.",
+							Description: "Name of the Kubernetes Cluster.",
 						},
 						"cloud_account": {
 							Type:        schema.TypeSet,


### PR DESCRIPTION
closes #63 

The description updates are not rendered in the documentation due to this bug:
https://github.com/hashicorp/terraform-plugin-docs/issues/64