### PR TITLE
Resource Enhancements: wiz_control

### DIFF
--- a/internal/provider/resource_control.go
+++ b/internal/provider/resource_control.go
@@ -269,6 +269,12 @@ func resourceWizControlRead(ctx context.Context, d *schema.ResourceData, m inter
 		return append(diags, diag.FromErr(err)...)
 	}
 
+	b, _ := json.Marshal(data.Control.Query)
+	err = d.Set("query", string(b))
+	if err != nil {
+		return append(diags, diag.FromErr(err)...)
+	}
+
 	return diags
 }
 


### PR DESCRIPTION
Hi,

We noticed that `query` wasn't being set at all during READ calls for `wiz_control`. Figured this simple marshaling and setting would work. If not, I'm happy to change the implementation.
