### PR TITLE
kubernetes clusters pagination support

### DIFF
--- a/docs/data-sources/kubernetes_clusters.md
+++ b/docs/data-sources/kubernetes_clusters.md
@@ -41,7 +41,7 @@ data "wiz_kubernetes_clusters" "myclusters" {
         - OpenShift
         - Kubernetes
 - `external_ids` (List of String) The ID(s) to search by. i.e `Azure Subscription ID` or `AWS account number`.
-- `first` (Number) How many matches to return.
+- `first` (Number) How many matches to return, maximum is `500` per page.
     - Defaults to `50`.
 - `kind` (List of String) Query Kubernetes Cluster of specific kind(s) or cloud provider(s).
     - Allowed values: 
@@ -51,7 +51,9 @@ data "wiz_kubernetes_clusters" "myclusters" {
         - OKE
         - OPEN_SHIFT
         - SELF_HOSTED
-- `search` (String) Free text search.
+- `max_pages` (Number) How many pages to return. 0 means all pages.
+    - Defaults to `0`.
+- `search` (String) Free text search. Specify empty string to return all kubernetes clusters
 
 ### Read-Only
 

--- a/internal/acceptance/data_source_kubernetes_clusters_test.go
+++ b/internal/acceptance/data_source_kubernetes_clusters_test.go
@@ -1,0 +1,84 @@
+package acceptance
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+// TestAccDatasourceWizKubernetesClusters_basic tests the basic functionality of the datasource
+// wiz_kubernetes_clusters. The assumption is that at least two clusters exist in the Wiz tenant in order
+// to validate pagination functionality
+func TestAccDatasourceWizKubernetesClusters_basic(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourceWizKubernetesClustersBasic(1),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr(
+						// check first kubernetes cluster has an id that matches the UUID regex
+						"data.wiz_kubernetes_clusters.foo",
+						"kubernetes_clusters.0.id",
+						regexp.MustCompile(UUIDPattern),
+					),
+					resource.TestMatchResourceAttr(
+						// check first kubernetes cluster has a name that is set to a non-empty string
+						"data.wiz_kubernetes_clusters.foo",
+						"kubernetes_clusters.0.name",
+						regexp.MustCompile(`\w`),
+					),
+					resource.TestMatchResourceAttr(
+						// check cloud_account_block has id that matches the UUID regex
+						"data.wiz_kubernetes_clusters.foo",
+						"kubernetes_clusters.0.cloud_account.0.id",
+						regexp.MustCompile(UUIDPattern),
+					),
+					resource.TestMatchResourceAttr(
+						// check cloud_account_block has external_id set to a non-empty string, different cloud providers have different formats
+						"data.wiz_kubernetes_clusters.foo",
+						"kubernetes_clusters.0.cloud_account.0.external_id",
+						regexp.MustCompile(`\w`),
+					),
+					resource.TestMatchResourceAttr(
+						// check cloud_account_block has name set to a non-empty string
+						"data.wiz_kubernetes_clusters.foo",
+						"kubernetes_clusters.0.cloud_account.0.name",
+						regexp.MustCompile(`\w`),
+					),
+					resource.TestMatchResourceAttr(
+						// check cloud_account_block has cloud_provider set to a non-empty string
+						"data.wiz_kubernetes_clusters.foo",
+						"kubernetes_clusters.0.cloud_account.0.cloud_provider",
+						regexp.MustCompile(`\w`),
+					),
+				),
+			},
+			{
+				Config: testAccDatasourceWizKubernetesClustersBasic(2),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr(
+						// check that the second kubernetes cluster has an id that matches the UUID regex
+						"data.wiz_kubernetes_clusters.foo",
+						"kubernetes_clusters.1.id",
+						regexp.MustCompile(`\w`),
+					),
+				),
+			},
+		},
+	})
+}
+
+func testAccDatasourceWizKubernetesClustersBasic(maxPages int) string {
+	return fmt.Sprintf(`
+	data "wiz_kubernetes_clusters" "foo" {
+		first  = 1
+		max_pages = %d
+		search = ""
+	  }
+	  
+`, maxPages)
+}

--- a/internal/provider/data_source_kubernetes_clusters_test.go
+++ b/internal/provider/data_source_kubernetes_clusters_test.go
@@ -19,24 +19,52 @@ func TestFlattenKubernetesClusters(t *testing.T) {
 					"cloud_provider": "AWS",
 					"external_id":    "151668690081",
 					"id":             "31e5304c-baca-54fa-bff3-aaf493eaeae0",
-					"name":           "MYK8S_TENANT_STAGE",
+					"name":           "AWS",
+				},
+			},
+		},
+		map[string]interface{}{
+			"id":   "8f137cbc-0810-55ff-acd6-f7574eb0d072",
+			"name": "24x7-prod",
+			"cloud_account": []interface{}{
+				map[string]interface{}{
+					"cloud_provider": "AZURE",
+					"external_id":    "31e5304c-baca-54fa-bff3-aaf493eaeae2",
+					"id":             "31e5304c-baca-54fa-bff3-aaf493eaeae0",
+					"name":           "AZURE",
 				},
 			},
 		},
 	}
 
-	var clusterLinks = &[]*wiz.KubernetesCluster{
-		{
-			ID:   "8f137cbc-0810-55ff-acd6-f7574eb0d071",
-			Name: "24x7-dev",
-			CloudAccount: *&wiz.CloudAccount{
-				ID:            "31e5304c-baca-54fa-bff3-aaf493eaeae0",
-				ExternalID:    "151668690081",
-				CloudProvider: "AWS",
-				Name:          "MYK8S_TENANT_STAGE",
+	clusters := &ReadKubernetesClusters{
+		KubernetesClusters: wiz.KubernetesClusterConnection{
+			Nodes: []*wiz.KubernetesCluster{
+				{
+					ID:   "8f137cbc-0810-55ff-acd6-f7574eb0d071",
+					Name: "24x7-dev",
+					CloudAccount: wiz.CloudAccount{
+						ID:            "31e5304c-baca-54fa-bff3-aaf493eaeae0",
+						ExternalID:    "151668690081",
+						CloudProvider: "AWS",
+						Name:          "AWS",
+					},
+				},
+				{
+					ID:   "8f137cbc-0810-55ff-acd6-f7574eb0d072",
+					Name: "24x7-prod",
+					CloudAccount: wiz.CloudAccount{
+						ID:            "31e5304c-baca-54fa-bff3-aaf493eaeae0",
+						ExternalID:    "31e5304c-baca-54fa-bff3-aaf493eaeae2",
+						CloudProvider: "AZURE",
+						Name:          "AZURE",
+					},
+				},
 			},
-		},
-	}
+		}}
+
+	clusterLinks := make([]interface{}, 0)
+	clusterLinks = append(clusterLinks, clusters)
 
 	flattened := flattenClusters(ctx, clusterLinks)
 


### PR DESCRIPTION
Added pagination support and acc tests for `wiz_kubernetes_clusters`
Closes #129
Closes #102

```sh
TF_ACC=1 go test ./internal/acceptance/... -v -run='TestAccDatasourceWizKubernetesClusters_basic' #   'TestAccResourceWizServiceAccount_basic'
=== RUN   TestAccDatasourceWizKubernetesClusters_basic
2023/05/11 15:55:31 [DEBUG] POST https://auth.app.wiz.io/oauth/token
2023/05/11 15:55:32 [DEBUG] POST https://api.eu1.app.wiz.io/graphql
2023/05/11 15:55:33 [DEBUG] POST https://auth.app.wiz.io/oauth/token
2023/05/11 15:55:33 [DEBUG] POST https://api.eu1.app.wiz.io/graphql
2023/05/11 15:55:34 [DEBUG] POST https://auth.app.wiz.io/oauth/token
2023/05/11 15:55:34 [DEBUG] POST https://api.eu1.app.wiz.io/graphql
2023/05/11 15:55:34 [DEBUG] POST https://auth.app.wiz.io/oauth/token
2023/05/11 15:55:35 [DEBUG] POST https://api.eu1.app.wiz.io/graphql
2023/05/11 15:55:35 [DEBUG] POST https://auth.app.wiz.io/oauth/token
2023/05/11 15:55:36 [DEBUG] POST https://api.eu1.app.wiz.io/graphql
2023/05/11 15:55:36 [DEBUG] POST https://auth.app.wiz.io/oauth/token
2023/05/11 15:55:36 [DEBUG] POST https://api.eu1.app.wiz.io/graphql
2023/05/11 15:55:36 [DEBUG] POST https://api.eu1.app.wiz.io/graphql
2023/05/11 15:55:37 [DEBUG] POST https://auth.app.wiz.io/oauth/token
2023/05/11 15:55:37 [DEBUG] POST https://api.eu1.app.wiz.io/graphql
2023/05/11 15:55:37 [DEBUG] POST https://api.eu1.app.wiz.io/graphql
2023/05/11 15:55:38 [DEBUG] POST https://auth.app.wiz.io/oauth/token
2023/05/11 15:55:38 [DEBUG] POST https://api.eu1.app.wiz.io/graphql
2023/05/11 15:55:39 [DEBUG] POST https://api.eu1.app.wiz.io/graphql
2023/05/11 15:55:39 [DEBUG] POST https://auth.app.wiz.io/oauth/token
2023/05/11 15:55:39 [DEBUG] POST https://api.eu1.app.wiz.io/graphql
2023/05/11 15:55:39 [DEBUG] POST https://api.eu1.app.wiz.io/graphql
2023/05/11 15:55:39 [DEBUG] POST https://auth.app.wiz.io/oauth/token
2023/05/11 15:55:40 [DEBUG] POST https://api.eu1.app.wiz.io/graphql
2023/05/11 15:55:40 [DEBUG] POST https://api.eu1.app.wiz.io/graphql
--- PASS: TestAccDatasourceWizKubernetesClusters_basic (9.13s)
PASS
ok      wiz.io/hashicorp/terraform-provider-wiz/internal/acceptance     9.382s
```
