### PR TITLE
Acceptance Tests: wiz_user

### DIFF
--- a/internal/acceptance/provider_test.go
+++ b/internal/acceptance/provider_test.go
@@ -39,6 +39,24 @@ func testAccPreCheck(t *testing.T) {
 	}
 }
 
+func testAccPreCheckUser(t *testing.T) {
+	// You can add code here to run prior to any test case execution, for example assertions
+	// about the appropriate environment variables being set are common to see in a pre-check
+	// function.
+	if v := os.Getenv("WIZ_URL"); v == "" {
+		t.Fatal("WIZ_URL must be set for acceptance tests")
+	}
+	if v := os.Getenv("WIZ_AUTH_CLIENT_ID"); v == "" {
+		t.Fatal("WIZ_AUTH_CLIENT_ID must be set for acceptance tests")
+	}
+	if v := os.Getenv("WIZ_AUTH_CLIENT_SECRET"); v == "" {
+		t.Fatal("WIZ_AUTH_CLIENT_SECRET must be set for acceptance tests")
+	}
+	if v := os.Getenv("WIZ_SMTP_DOMAIN"); v == "" {
+		t.Fatal("WIZ_SMTP_DOMAIN must be set for wiz_user acceptance tests")
+	}
+}
+
 func testAccPreCheckIntegrationServiceNow(t *testing.T) {
 	// You can add code here to run prior to any test case execution, for example assertions
 	// about the appropriate environment variables being set are common to see in a pre-check

--- a/internal/acceptance/resource_user_test.go
+++ b/internal/acceptance/resource_user_test.go
@@ -1,0 +1,67 @@
+package acceptance
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccResourceWizUser_basic(t *testing.T) {
+	rName := acctest.RandomWithPrefix(ResourcePrefix)
+	smtpDomain := os.Getenv("WIZ_SMTP_DOMAIN")
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheckUser(t) },
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testResourceWizUserBasic(rName, smtpDomain),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						// check that name is correctly set
+						"wiz_user.foo",
+						"name",
+						rName,
+					),
+					resource.TestCheckResourceAttr(
+						// check that email is correctly set
+						"wiz_user.foo",
+						"email",
+						fmt.Sprintf("%s@%s", rName, smtpDomain),
+					),
+					resource.TestCheckResourceAttr(
+						// check that role is set to specified value
+						"wiz_user.foo",
+						"role",
+						"PROJECT_MEMBER",
+					),
+					resource.TestCheckResourceAttrSet(
+						// check for a set assigned project id
+						"wiz_user.foo",
+						"assigned_project_ids.0",
+					),
+					resource.TestCheckResourceAttrSet(
+						// check that send_email_invite is set (can be null)
+						"wiz_user.foo",
+						"send_email_invite",
+					),
+				),
+			},
+		},
+	})
+}
+
+func testResourceWizUserBasic(rName string, smtpDomain string) string {
+	project := uuid.New().String()
+	return fmt.Sprintf(`
+	resource "wiz_user" "foo" {
+		name                 = "%[1]s"
+		email                = "%[1]s@%s"
+		role                 = "PROJECT_MEMBER"
+		assigned_project_ids = [ "%s" ]
+	  } 
+`, rName, smtpDomain, project)
+}


### PR DESCRIPTION
- Acceptance tests for resource `wiz_user`

closes #112 

```sh
TF_ACC=1 go test ./internal/acceptance/... -v -run='TestAccResourceWizUser_basic'
=== RUN   TestAccResourceWizUser_basic
2023/05/22 10:18:16 [DEBUG] POST https://auth.app.wiz.io/oauth/token
2023/05/22 10:18:18 [DEBUG] POST https://auth.app.wiz.io/oauth/token
2023/05/22 10:18:19 [DEBUG] POST https://auth.app.wiz.io/oauth/token
2023/05/22 10:18:20 [DEBUG] POST https://api.eu1.app.wiz.io/graphql
2023/05/22 10:18:22 [DEBUG] POST https://api.eu1.app.wiz.io/graphql
2023/05/22 10:18:22 [DEBUG] POST https://auth.app.wiz.io/oauth/token
2023/05/22 10:18:23 [DEBUG] POST https://auth.app.wiz.io/oauth/token
2023/05/22 10:18:25 [DEBUG] POST https://api.eu1.app.wiz.io/graphql
2023/05/22 10:18:25 [DEBUG] POST https://auth.app.wiz.io/oauth/token
2023/05/22 10:18:26 [DEBUG] POST https://auth.app.wiz.io/oauth/token
2023/05/22 10:18:27 [DEBUG] POST https://api.eu1.app.wiz.io/graphql
--- PASS: TestAccResourceWizUser_basic (12.41s)
PASS
ok      wiz.io/hashicorp/terraform-provider-wiz/internal/acceptance     12.849s
```