### PR TITLE
Resource Enhancement: wiz_cloud_config_rule

### DIFF
--- a/docs/data-sources/cloud_config_rules.md
+++ b/docs/data-sources/cloud_config_rules.md
@@ -67,6 +67,7 @@ data "wiz_cloud_config_rules" "aws_critical" {
         - KUBERNETES
         - AZURE_RESOURCE_MANAGER
         - DOCKER_FILE
+        - ADMISSION_CONTROLLER
 - `project` (List of String) Search by project.
 - `risk_equals_all` (List of String)
 - `risk_equals_any` (List of String)

--- a/docs/resources/cloud_config_rule.md
+++ b/docs/resources/cloud_config_rule.md
@@ -117,3 +117,4 @@ Required:
         - KUBERNETES
         - AZURE_RESOURCE_MANAGER
         - DOCKER_FILE
+        - ADMISSION_CONTROLLER

--- a/internal/acceptance/common.go
+++ b/internal/acceptance/common.go
@@ -19,4 +19,6 @@ const (
 	TcJira TestCase = "JIRA"
 	// TcSubscriptionResourceGroups test case
 	TcSubscriptionResourceGroups TestCase = "SUBSCRIPTION_RESOURCE_GROUPS"
+	// TcCloudConfigRule test case
+	TcCloudConfigRule TestCase = "CLOUD_CONFIG_RULE"
 )

--- a/internal/acceptance/provider_test.go
+++ b/internal/acceptance/provider_test.go
@@ -41,6 +41,8 @@ func testAccPreCheck(t *testing.T, tc TestCase) {
 		envVars = append(commonEnvVars, "WIZ_INTEGRATION_JIRA_URL", "WIZ_INTEGRATION_JIRA_USERNAME", "WIZ_INTEGRATION_JIRA_PASSWORD", "WIZ_INTEGRATION_JIRA_PROJECT")
 	case TcSubscriptionResourceGroups:
 		envVars = append(commonEnvVars, "WIZ_SUBSCRIPTION_ID")
+	case TcCloudConfigRule:
+		envVars = append(commonEnvVars, "WIZ_SUBSCRIPTION_ID")
 	default:
 		t.Fatalf("unknown testCase: %s", tc)
 	}

--- a/internal/acceptance/resource_cloud_config_rule_test.go
+++ b/internal/acceptance/resource_cloud_config_rule_test.go
@@ -1,0 +1,133 @@
+package acceptance
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccResourceWizCloudConfigRule_basic(t *testing.T) {
+	subscriptionID := os.Getenv("WIZ_SUBSCRIPTION_ID")
+	rName := acctest.RandomWithPrefix(ResourcePrefix)
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t, TestCase(TcCloudConfigRule)) },
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testResourceWizCloudConfigRuleBasic(rName, subscriptionID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"wiz_cloud_config_rule.foo",
+						"name",
+						rName,
+					),
+					resource.TestCheckResourceAttr(
+						"wiz_cloud_config_rule.foo",
+						"description",
+						"test description",
+					),
+					resource.TestCheckResourceAttr(
+						"wiz_cloud_config_rule.foo",
+						"remediation_instructions",
+						"fix it",
+					),
+					resource.TestCheckResourceAttr(
+						"wiz_cloud_config_rule.foo",
+						"target_native_types.0",
+						"account",
+					),
+					resource.TestCheckResourceAttr(
+						"wiz_cloud_config_rule.foo",
+						"scope_account_ids.0",
+						subscriptionID,
+					),
+					resource.TestCheckResourceAttr(
+						"wiz_cloud_config_rule.foo",
+						"function_as_control",
+						"false",
+					),
+					resource.TestCheckResourceAttr(
+						"wiz_cloud_config_rule.foo",
+						"enabled",
+						"false",
+					),
+					resource.TestCheckResourceAttr(
+						"wiz_cloud_config_rule.foo",
+						"severity",
+						"HIGH",
+					),
+					resource.TestCheckResourceAttr(
+						"wiz_cloud_config_rule.foo",
+						"iac_matchers.0.type",
+						"ADMISSION_CONTROLLER",
+					),
+					resource.TestMatchResourceAttr(
+						"wiz_cloud_config_rule.foo",
+						"iac_matchers.0.rego_code",
+						regexp.MustCompile(`\w`),
+					),
+				),
+			},
+		},
+	})
+}
+
+func testResourceWizCloudConfigRuleBasic(rName string, subscriptionID string) string {
+	return fmt.Sprintf(`
+	resource "wiz_cloud_config_rule" "foo" {
+		name        = "%s"
+		description = "test description"
+		target_native_types = [
+		  "account",
+		]
+		scope_account_ids = [
+		  "%s",
+		]
+		function_as_control      = false
+		remediation_instructions = "fix it"
+		enabled                  = false
+		severity                 = "HIGH"
+		opa_policy               = <<EOT
+	  package wiz
+
+	  default result = "pass"
+	  EOT
+		iac_matchers {
+		  type      = "ADMISSION_CONTROLLER"
+		  rego_code = <<EOT
+	  package wiz
+
+	  import data.generic.cloudformation as cloudFormationLib
+
+	  import data.generic.common as common_lib
+
+	  WizPolicy[result] {
+			  resource := input.document[i].Resources[name]
+			  resource.Type == "AWS::Config::ConfigRule"
+			  not hasAccessKeyRotationRule(resource)
+
+			  result := {
+					  "documentId": input.document[i].id,
+					  "searchKey": sprintf("Resources.%%s", [name]),
+					  "issueType": "MissingAttribute",
+					  "keyExpectedValue": sprintf("Resources.%%s has a ConfigRule defining rotation period on AccessKeys.", [name]),
+					  "keyActualValue": sprintf("Resources.%%s doesn't have a ConfigRule defining rotation period on AccessKeys.", [name]),
+					  "resourceTags": cloudFormationLib.getCFTags(resource),
+			  }
+	  }
+
+	  hasAccessKeyRotationRule(configRule) {
+			  configRule.Properties.Source.SourceIdentifier == "ACCESS_KEYS_ROTATED"
+	  } else = false {
+			  true
+	  }
+	  EOT
+		}
+	  }
+`, rName, subscriptionID)
+}

--- a/internal/wiz/enums.go
+++ b/internal/wiz/enums.go
@@ -222,6 +222,7 @@ var CloudConfigurationRuleMatcherType = []string{
 	"KUBERNETES",
 	"AZURE_RESOURCE_MANAGER",
 	"DOCKER_FILE",
+	"ADMISSION_CONTROLLER",
 }
 
 // CloudProvider enum
@@ -327,6 +328,7 @@ var CloudConfigurationRuleMatcherTypeFilter = []string{
 	"KUBERNETES",
 	"AZURE_RESOURCE_MANAGER",
 	"DOCKER_FILE",
+	"ADMISSION_CONTROLLER",
 }
 
 // DeploymentModel enum


### PR DESCRIPTION
closes #153 

added acc test:
```sh
TF_ACC=1 go test ./internal/acceptance/... -v -run='TestAccResourceWizCloudConfigRule_basic'
=== RUN   TestAccResourceWizCloudConfigRule_basic
2023/08/09 10:05:47 [DEBUG] POST https://auth.app.wiz.io/oauth/token
2023/08/09 10:05:47 [DEBUG] POST https://auth.app.wiz.io/oauth/token
2023/08/09 10:05:48 [DEBUG] POST https://auth.app.wiz.io/oauth/token
2023/08/09 10:05:49 [DEBUG] POST https://api.eu4.app.wiz.io/graphql
2023/08/09 10:05:49 [DEBUG] POST https://api.eu4.app.wiz.io/graphql
2023/08/09 10:05:49 [DEBUG] POST https://auth.app.wiz.io/oauth/token
2023/08/09 10:05:50 [DEBUG] POST https://auth.app.wiz.io/oauth/token
2023/08/09 10:05:51 [DEBUG] POST https://api.eu4.app.wiz.io/graphql
2023/08/09 10:05:51 [DEBUG] POST https://auth.app.wiz.io/oauth/token
2023/08/09 10:05:52 [DEBUG] POST https://auth.app.wiz.io/oauth/token
2023/08/09 10:05:52 [DEBUG] POST https://api.eu4.app.wiz.io/graphql
--- PASS: TestAccResourceWizCloudConfigRule_basic (6.15s)
PASS
ok      wiz.io/hashicorp/terraform-provider-wiz/internal/acceptance     6.436s
```