### PR TITLE
Avoid resource_control drift due to whitespace in queries

### DIFF
--- a/internal/provider/resource_control.go
+++ b/internal/provider/resource_control.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"reflect"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -68,6 +69,12 @@ func resourceWizControl() *schema.Resource {
 				ValidateDiagFunc: validation.ToDiagFunc(
 					validation.StringIsJSON,
 				),
+				DiffSuppressFunc: func(k, oldValue, newValue string, d *schema.ResourceData) bool {
+					var ov, nv interface{}
+					_ = json.Unmarshal([]byte(oldValue), &ov)
+					_ = json.Unmarshal([]byte(newValue), &nv)
+					return reflect.DeepEqual(ov, nv)
+				},
 			},
 			"scope_query": {
 				Type:        schema.TypeString,
@@ -76,6 +83,12 @@ func resourceWizControl() *schema.Resource {
 				ValidateDiagFunc: validation.ToDiagFunc(
 					validation.StringIsJSON,
 				),
+				DiffSuppressFunc: func(k, oldValue, newValue string, d *schema.ResourceData) bool {
+					var ov, nv interface{}
+					_ = json.Unmarshal([]byte(oldValue), &ov)
+					_ = json.Unmarshal([]byte(newValue), &nv)
+					return reflect.DeepEqual(ov, nv)
+				},
 			},
 			"severity": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
As reported in hashicorp/terraform#23928, reading a string from a file and comparing it to the terraform state may produce a drift due to inconsistencies (ie. Linux vs Windows line endings). This PR suppresses any drift caused by differences between the desired state and the stored state, by unmarshalling the JSONs and comparing the resulting objects.