### PR TITLE
Remove Disk Analyser Config from GCP Connector

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -67,6 +67,8 @@ jobs:
       with:
         go-version-file: 'go.mod'
         cache: true
+    - name: Setup terraform
+      uses: hashicorp/setup-terraform@v3
     - run: go generate ./...
     - name: git diff
       run: |

--- a/docs/resources/connector_gcp.md
+++ b/docs/resources/connector_gcp.md
@@ -27,7 +27,6 @@ resource "wiz_connector_gcp" "example" {
       "excludedProjects" : [],
       "includedFolders" : [],
       "excludedFolders" : [],
-      "diskAnalyzerInFlightDisabled" : false,
       "auditLogMonitorEnabled" : false
     }
   )
@@ -47,7 +46,6 @@ resource "wiz_connector_gcp" "example" {
       "excludedProjects" : [],
       "includedFolders" : [],
       "excludedFolders" : [],
-      "diskAnalyzerInFlightDisabled" : false,
       "auditLogMonitorEnabled" : false
     }
   )
@@ -71,7 +69,6 @@ resource "wiz_connector_gcp" "example" {
 ### Read-Only
 
 - `audit_log_monitor_enabled` (Boolean) Whether audit log monitor is enabled. Note an advanced license is required.
-- `disk_analyzer_inflight_disabled` (Boolean) If using Outpost, whether disk analyzer inflight scanning is disabled.
 - `events_pub_sub_subscription_id` (String) If using Wiz Cloud Events, the Pub/Sub Subscription ID.
 - `events_topic_name` (String) If using Wiz Cloud Events, the Topic Name in format `projects/<project_id>/topics/<topic_id>`.
 - `excluded_folders` (List of String) The GCP folders excluded by the connector.

--- a/examples/resources/wiz_connector_gcp/resource.tf
+++ b/examples/resources/wiz_connector_gcp/resource.tf
@@ -12,7 +12,6 @@ resource "wiz_connector_gcp" "example" {
       "excludedProjects" : [],
       "includedFolders" : [],
       "excludedFolders" : [],
-      "diskAnalyzerInFlightDisabled" : false,
       "auditLogMonitorEnabled" : false
     }
   )
@@ -32,7 +31,6 @@ resource "wiz_connector_gcp" "example" {
       "excludedProjects" : [],
       "includedFolders" : [],
       "excludedFolders" : [],
-      "diskAnalyzerInFlightDisabled" : false,
       "auditLogMonitorEnabled" : false
     }
   )

--- a/internal/acceptance/resource_connector_gcp_test.go
+++ b/internal/acceptance/resource_connector_gcp_test.go
@@ -69,7 +69,6 @@ func testResourceWizConnectorGcpBasic(rName string) string {
 			"excludedProjects" : [],
 			"includedFolders" : [],
 			"excludedFolders" : [],
-			"diskAnalyzerInFlightDisabled" : false,
 			"auditLogMonitorEnabled" : false,
 		  }
 		)

--- a/internal/acceptance/resource_connector_gcp_test.go
+++ b/internal/acceptance/resource_connector_gcp_test.go
@@ -46,13 +46,8 @@ func TestAccResourceWizConnectorGcp_basic(t *testing.T) {
 					),
 					resource.TestCheckResourceAttr(
 						"wiz_connector_gcp.foo",
-						"disk_analyzer_inflight_disabled",
-						"false",
-					),
-					resource.TestCheckResourceAttr(
-						"wiz_connector_gcp.foo",
 						"extra_config",
-						"{\"auditLogMonitorEnabled\":false,\"diskAnalyzerInFlightDisabled\":false,\"excludedFolders\":[],\"excludedProjects\":[],\"includedFolders\":[],\"projects\":[]}",
+						"{\"auditLogMonitorEnabled\":false,\"excludedFolders\":[],\"excludedProjects\":[],\"includedFolders\":[],\"projects\":[]}",
 					),
 				),
 			},

--- a/internal/provider/resource_connector_gcp.go
+++ b/internal/provider/resource_connector_gcp.go
@@ -100,11 +100,7 @@ func resourceWizConnectorGcp() *schema.Resource {
 				Description: "Whether audit log monitor is enabled. Note an advanced license is required.",
 				Computed:    true,
 			},
-			"disk_analyzer_inflight_disabled": {
-				Type:        schema.TypeBool,
-				Description: "If using Outpost, whether disk analyzer inflight scanning is disabled.",
-				Computed:    true,
-			},
+
 			"events_topic_name": {
 				Type:        schema.TypeString,
 				Description: "If using Wiz Cloud Events, the Topic Name in format `projects/<project_id>/topics/<topic_id>`.",
@@ -210,7 +206,6 @@ func resourceWizConnectorGcpRead(ctx context.Context, d *schema.ResourceData, m 
 	      config {
 	        ... on ConnectorConfigGCP {
 	          auditLogMonitorEnabled
-	          diskAnalyzerInFlightDisabled
 	          includedFolders
 	          excludedFolders
 	          excludedProjects
@@ -286,10 +281,6 @@ func resourceWizConnectorGcpRead(ctx context.Context, d *schema.ResourceData, m 
 	}
 
 	err = d.Set("projects", utils.ConvertSliceToGenericArray(connectorConfig.Projects))
-	if err != nil {
-		return append(diags, diag.FromErr(err)...)
-	}
-	err = d.Set("disk_analyzer_inflight_disabled", connectorConfig.DiskAnalyzerInFlightDisabled)
 	if err != nil {
 		return append(diags, diag.FromErr(err)...)
 	}

--- a/internal/wiz/structs.go
+++ b/internal/wiz/structs.go
@@ -635,26 +635,26 @@ type OutpostAWSConfig struct {
 
 // ConnectorConfigGCP struct -- updates
 type ConnectorConfigGCP struct {
-	AuthProviderX509CertURL      string                      `json:"auth_provider_x509_cert_url"`
-	AuthURI                      string                      `json:"auth_uri"`
-	AuditLogMonitorEnabled       bool                        `json:"auditLogMonitorEnabled"`
-	AuditLogsConfig              ConnectorConfigGCPAuditLogs `json:"auditLogsConfig"`
-	ClientEmail                  string                      `json:"client_email"`
-	ClientID                     string                      `json:"client_id"`
-	ClientX509CertURL            string                      `json:"client_x509_cert_url"`
-	DelegateUser                 string                      `json:"delegateUser"`
-	ExcludedFolders              []string                    `json:"excludedFolders"`
-	ExcludedProjects             []string                    `json:"excludedProjects"`
-	FolderID                     string                      `json:"folder_id"`
-	IncludedFolders              []string                    `json:"includedFolders"`
-	IsManagedIdentity            bool                        `json:"isManagedIdentity"`
-	OrganizationID               string                      `json:"organization_id"`
-	PrivateKey                   string                      `json:"private_key"`
-	PrivateKeyID                 string                      `json:"private_key_id"`
-	ProjectID                    string                      `json:"project_id"`
-	Projects                     []string                    `json:"projects"`
-	TokenURI                     string                      `json:"token_uri"`
-	Type                         string                      `json:"type"`
+	AuthProviderX509CertURL string                      `json:"auth_provider_x509_cert_url"`
+	AuthURI                 string                      `json:"auth_uri"`
+	AuditLogMonitorEnabled  bool                        `json:"auditLogMonitorEnabled"`
+	AuditLogsConfig         ConnectorConfigGCPAuditLogs `json:"auditLogsConfig"`
+	ClientEmail             string                      `json:"client_email"`
+	ClientID                string                      `json:"client_id"`
+	ClientX509CertURL       string                      `json:"client_x509_cert_url"`
+	DelegateUser            string                      `json:"delegateUser"`
+	ExcludedFolders         []string                    `json:"excludedFolders"`
+	ExcludedProjects        []string                    `json:"excludedProjects"`
+	FolderID                string                      `json:"folder_id"`
+	IncludedFolders         []string                    `json:"includedFolders"`
+	IsManagedIdentity       bool                        `json:"isManagedIdentity"`
+	OrganizationID          string                      `json:"organization_id"`
+	PrivateKey              string                      `json:"private_key"`
+	PrivateKeyID            string                      `json:"private_key_id"`
+	ProjectID               string                      `json:"project_id"`
+	Projects                []string                    `json:"projects"`
+	TokenURI                string                      `json:"token_uri"`
+	Type                    string                      `json:"type"`
 }
 
 // ConnectorConfigGCPAuditLogs struct -- updates

--- a/internal/wiz/structs.go
+++ b/internal/wiz/structs.go
@@ -643,7 +643,6 @@ type ConnectorConfigGCP struct {
 	ClientID                     string                      `json:"client_id"`
 	ClientX509CertURL            string                      `json:"client_x509_cert_url"`
 	DelegateUser                 string                      `json:"delegateUser"`
-	DiskAnalyzerInFlightDisabled bool                        `json:"diskAnalyzerInFlightDisabled"`
 	ExcludedFolders              []string                    `json:"excludedFolders"`
 	ExcludedProjects             []string                    `json:"excludedProjects"`
 	FolderID                     string                      `json:"folder_id"`


### PR DESCRIPTION
This PR removed Disk Analyser Config from GCP Connector. This is due to changes in wiz api where this attribute is not present anymore

closes #237 
possible relation to #234 