### PR TITLE
Fix: Remove Disk Analyser Config from the AWS Connector

### DIFF
--- a/docs/resources/connector_aws.md
+++ b/docs/resources/connector_aws.md
@@ -23,7 +23,6 @@ resource "wiz_connector_aws" "example" {
   extra_config = jsonencode(
     {
       "skipOrganizationScan" : true,
-      "diskAnalyzerInFlightDisabled" : false,
       "optedInRegions" : ["us-east-1"],
       "excludedAccounts" : [],
       "excludedOUs" : [],
@@ -51,7 +50,6 @@ resource "wiz_connector_aws" "example" {
       "excludedAccounts" : ["100000000009", "100000000010", "100000000013"],
       "excludedOUs" : ["EXCLUDE-ME"],
       "auditLogMonitorEnabled" : false,
-      "diskAnalyzerInFlightDisabled" : false,
       "skipOrganizationScan" : true,
       "optedInRegions" : [],
       "cloudTrailConfig" : {
@@ -83,7 +81,6 @@ resource "wiz_connector_aws" "example" {
 
 - `audit_log_monitor_enabled` (Boolean) Whether audit log monitor is enabled. Note an advanced license is required.
 - `customer_role_arn` (String) The AWS customer role arn for Wiz to assume.
-- `disk_analyzer_inflight_disabled` (Boolean) If using Outpost, whether disk analyzer inflight scanning is disabled.
 - `events_cloudtrail_bucket_name` (String) If using Wiz Cloud Events, the CloudTrail bucket name.
 - `events_cloudtrail_bucket_sub_account` (String) If using Wiz Cloud Events and CloudTrail is organizational, the CloudTrail bucket sub account.
 - `events_cloudtrail_organization` (String) If using Wiz Cloud Events and CloudTrail is deployed to AWS organizations, the organizational ID.

--- a/examples/resources/wiz_connector_aws/resource.tf
+++ b/examples/resources/wiz_connector_aws/resource.tf
@@ -8,7 +8,6 @@ resource "wiz_connector_aws" "example" {
   extra_config = jsonencode(
     {
       "skipOrganizationScan" : true,
-      "diskAnalyzerInFlightDisabled" : false,
       "optedInRegions" : ["us-east-1"],
       "excludedAccounts" : [],
       "excludedOUs" : [],
@@ -36,7 +35,6 @@ resource "wiz_connector_aws" "example" {
       "excludedAccounts" : ["100000000009", "100000000010", "100000000013"],
       "excludedOUs" : ["EXCLUDE-ME"],
       "auditLogMonitorEnabled" : false,
-      "diskAnalyzerInFlightDisabled" : false,
       "skipOrganizationScan" : true,
       "optedInRegions" : [],
       "cloudTrailConfig" : {

--- a/internal/acceptance/resource_connector_aws_test.go
+++ b/internal/acceptance/resource_connector_aws_test.go
@@ -61,13 +61,8 @@ func TestAccResourceWizConnectorAws_basic(t *testing.T) {
 					),
 					resource.TestCheckResourceAttr(
 						"wiz_connector_aws.foo",
-						"disk_analyzer_inflight_disabled",
-						"false",
-					),
-					resource.TestCheckResourceAttr(
-						"wiz_connector_aws.foo",
 						"extra_config",
-						"{\"auditLogMonitorEnabled\":false,\"diskAnalyzerInFlightDisabled\":false,\"excludedAccounts\":[\"100000000009\"],\"excludedOUs\":[\"DEV\"],\"optedInRegions\":[\"us-east-1\"],\"skipOrganizationScan\":true}",
+						"{\"auditLogMonitorEnabled\":false,\"excludedAccounts\":[\"100000000009\"],\"excludedOUs\":[\"DEV\"],\"optedInRegions\":[\"us-east-1\"],\"skipOrganizationScan\":true}",
 					),
 					resource.TestCheckResourceAttr(
 						"wiz_connector_aws.foo",
@@ -90,7 +85,6 @@ func testResourceWizConnectorAwsBasic(rName string) string {
 		extra_config = jsonencode(
 			{
 				"skipOrganizationScan" : true,
-				"diskAnalyzerInFlightDisabled" : false,
 				"optedInRegions" : ["us-east-1"],
 				"excludedAccounts" : ["100000000009"],
 				"excludedOUs" : ["DEV"],

--- a/internal/provider/resource_connector_aws.go
+++ b/internal/provider/resource_connector_aws.go
@@ -63,11 +63,6 @@ func resourceWizConnectorAws() *schema.Resource {
 				Description: "Whether audit log monitor is enabled. Note an advanced license is required.",
 				Computed:    true,
 			},
-			"disk_analyzer_inflight_disabled": {
-				Type:        schema.TypeBool,
-				Description: "If using Outpost, whether disk analyzer inflight scanning is disabled.",
-				Computed:    true,
-			},
 			"skip_organization_scan": {
 				Type:        schema.TypeBool,
 				Description: "Whether to skip the organization scan (account-scoped only).",
@@ -201,7 +196,6 @@ func resourceWizConnectorAwsRead(ctx context.Context, d *schema.ResourceData, m 
 	      config {
 	        ... on ConnectorConfigAWS {
 	          region
-	          diskAnalyzerInFlightDisabled
 	          excludedAccounts
 	          excludedOUs
 	          externalIdNonce
@@ -311,10 +305,6 @@ func resourceWizConnectorAwsRead(ctx context.Context, d *schema.ResourceData, m 
 		return append(diags, diag.FromErr(err)...)
 	}
 	err = d.Set("customer_role_arn", connectorConfig.CustomerRoleARN)
-	if err != nil {
-		return append(diags, diag.FromErr(err)...)
-	}
-	err = d.Set("disk_analyzer_inflight_disabled", connectorConfig.DiskAnalyzerInFlightDisabled)
 	if err != nil {
 		return append(diags, diag.FromErr(err)...)
 	}

--- a/internal/wiz/structs.go
+++ b/internal/wiz/structs.go
@@ -670,19 +670,18 @@ type ConnectorConfigGCPPubSub struct {
 
 // ConnectorConfigAWS struct -- updates
 type ConnectorConfigAWS struct {
-	CustomerRoleARN              string                        `json:"customerRoleARN"`
-	SubAccountRole               string                        `json:"subAccountRole,omitempty"`
-	ExternalIDNonce              string                        `json:"externalIdNonce"`
-	Region                       string                        `json:"region,omitempty"`
-	DiskAnalyzer                 ConnectorAuthConfigAWSOutpost `json:"diskAnalyzer,omitempty"`
-	ExcludedAccounts             []string                      `json:"excludedAccounts,omitempty"`
-	IncludedAccounts             []string                      `json:"includedAccounts,omitempty"`
-	ExcludedOUs                  []string                      `json:"excludedOUs,omitempty"`
-	SkipOrganizationScan         bool                          `json:"skipOrganizationScan"`
-	OptedInRegions               []string                      `json:"optedInRegions,omitempty"`
-	AuditLogMonitorEnabled       bool                          `json:"auditLogMonitorEnabled"`
-	CloudTrailConfig             ConnectorConfigAWSCloudTrail  `json:"cloudTrailConfig,omitempty"`
-	DiskAnalyzerInFlightDisabled bool                          `json:"diskAnalyzerInFlightDisabled"`
+	CustomerRoleARN        string                        `json:"customerRoleARN"`
+	SubAccountRole         string                        `json:"subAccountRole,omitempty"`
+	ExternalIDNonce        string                        `json:"externalIdNonce"`
+	Region                 string                        `json:"region,omitempty"`
+	DiskAnalyzer           ConnectorAuthConfigAWSOutpost `json:"diskAnalyzer,omitempty"`
+	ExcludedAccounts       []string                      `json:"excludedAccounts,omitempty"`
+	IncludedAccounts       []string                      `json:"includedAccounts,omitempty"`
+	ExcludedOUs            []string                      `json:"excludedOUs,omitempty"`
+	SkipOrganizationScan   bool                          `json:"skipOrganizationScan"`
+	OptedInRegions         []string                      `json:"optedInRegions,omitempty"`
+	AuditLogMonitorEnabled bool                          `json:"auditLogMonitorEnabled"`
+	CloudTrailConfig       ConnectorConfigAWSCloudTrail  `json:"cloudTrailConfig,omitempty"`
 }
 
 // ConnectorAuthConfigAWSOutpost struct -- updates


### PR DESCRIPTION
This PR removes Disk Analyser Config from the AWS Connector. This is due to changes in wiz api where this attribute is not present anymore.

closes #238
related to #236

### Acceptance Test
```sh
=== RUN   TestAccResourceWizConnectorAws_basic
2025/01/09 09:55:22 [DEBUG] POST https://auth.app.wiz.io/oauth/token
2025/01/09 09:55:23 [DEBUG] POST https://auth.app.wiz.io/oauth/token
2025/01/09 09:55:23 [DEBUG] POST https://api.eu4.app.wiz.io/graphql
2025/01/09 09:55:24 [DEBUG] POST https://api.eu4.app.wiz.io/graphql
2025/01/09 09:55:24 [DEBUG] POST https://auth.app.wiz.io/oauth/token
2025/01/09 09:55:25 [DEBUG] POST https://auth.app.wiz.io/oauth/token
2025/01/09 09:55:25 [DEBUG] POST https://api.eu4.app.wiz.io/graphql
2025/01/09 09:55:25 [DEBUG] POST https://auth.app.wiz.io/oauth/token
2025/01/09 09:55:26 [DEBUG] POST https://auth.app.wiz.io/oauth/token
2025/01/09 09:55:26 [DEBUG] POST https://api.eu4.app.wiz.io/graphql
--- PASS: TestAccResourceWizConnectorAws_basic (7.08s)
PASS
ok  	wiz.io/hashicorp/terraform-provider-wiz/internal/acceptance	10.447s
```