### PR TITLE
Feature/saml group mapping description field

### DIFF
--- a/docs/resources/saml_group_mapping.md
+++ b/docs/resources/saml_group_mapping.md
@@ -24,6 +24,18 @@ resource "wiz_saml_group_mapping" "test_global_scope" {
   ]
 }
 
+# Configure SAML Group Role Mapping on a global scope, with optional description
+resource "wiz_saml_group_mapping" "test_global_scope" {
+  saml_idp_id = "test-saml-identity-provider"
+  group_mappings = [
+    {
+      provider_group_id = "global-reader-group-id"
+      role              = "PROJECT_READER"
+      description       = "Global Reader group mapping"
+    }
+  ]
+}
+
 # Configure SAML Group Role Mapping for a single project
 resource "wiz_saml_group_mapping" "test_single_project" {
   saml_idp_id = "test-saml-identity-provider"
@@ -102,6 +114,7 @@ Required:
 
 Optional:
 
+- `description` (String) Group Mapping description
 - `projects` (List of String) Project mapping
 
 ## Import

--- a/examples/resources/wiz_saml_group_mapping/resource.tf
+++ b/examples/resources/wiz_saml_group_mapping/resource.tf
@@ -9,6 +9,18 @@ resource "wiz_saml_group_mapping" "test_global_scope" {
   ]
 }
 
+# Configure SAML Group Role Mapping on a global scope, with optional description
+resource "wiz_saml_group_mapping" "test_global_scope" {
+  saml_idp_id = "test-saml-identity-provider"
+  group_mappings = [
+    {
+      provider_group_id = "global-reader-group-id"
+      role              = "PROJECT_READER"
+      description       = "Global Reader group mapping"
+    }
+  ]
+}
+
 # Configure SAML Group Role Mapping for a single project
 resource "wiz_saml_group_mapping" "test_single_project" {
   saml_idp_id = "test-saml-identity-provider"

--- a/internal/acceptance/resource_saml_group_mapping_test.go
+++ b/internal/acceptance/resource_saml_group_mapping_test.go
@@ -35,6 +35,11 @@ func TestAccResourceWizSAMLGroupMapping_basic(t *testing.T) {
 						"group_mapping.0.projects.0",
 						projectID,
 					),
+					resource.TestCheckResourceAttr(
+						"wiz_saml_group_mapping.foo",
+						"group_mapping.0.description",
+						"test mapping.",
+					),
 				),
 			},
 		},
@@ -51,6 +56,7 @@ func testResourceWizSAMLGroupMappingBasic(samlIdpID string, providerGroupID stri
 			projects = [
 			  "%s"
 			]
+			description = "test mapping."
 		  }
 		}`, samlIdpID, providerGroupID, projectID)
 }

--- a/internal/provider/resource_saml_group_mapping.go
+++ b/internal/provider/resource_saml_group_mapping.go
@@ -79,6 +79,11 @@ func resourceWizSAMLGroupMapping() *schema.Resource {
 								Type: schema.TypeString,
 							},
 						},
+						"description": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Description:  "Group Mapping description",
+						},
 					},
 				},
 			},
@@ -134,6 +139,7 @@ func resourceSAMLGroupMappingCreate(ctx context.Context, d *schema.ResourceData,
 		providerGroupID := groupMapping["provider_group_id"].(string)
 		role := groupMapping["role"].(string)
 		projectIDs := utils.ConvertListToString(groupMapping["projects"].([]interface{}))
+		description := groupMapping["description"].(string)
 
 		// verify the mapping doesn't already exist
 		matchingNodes, diags := querySAMLGroupMappings(ctx, m, samlIdpID, groupMappings)
@@ -152,6 +158,7 @@ func resourceSAMLGroupMappingCreate(ctx context.Context, d *schema.ResourceData,
 			ProviderGroupID: providerGroupID,
 			Role:            role,
 			Projects:        projectIDs,
+			Description:     description,
 		}
 		upsertGroupMappings = append(upsertGroupMappings, upsertGroupMapping)
 	}
@@ -261,6 +268,7 @@ func resourceSAMLGroupMappingRead(ctx context.Context, d *schema.ResourceData, m
 					"provider_group_id": matchingNode.ProviderGroupID,
 					"role":              matchingNode.Role.ID,
 					"projects":          extractProjectIDs(matchingNode.Projects),
+					"description":       matchingNode.Description,
 				}
 				newGroupMappings = append(newGroupMappings, newGroupMapping)
 			}
@@ -297,10 +305,12 @@ func resourceSAMLGroupMappingUpdate(ctx context.Context, d *schema.ResourceData,
 		providerGroupID := groupMapping["provider_group_id"].(string)
 		role := groupMapping["role"].(string)
 		projects := utils.ConvertListToString(groupMapping["projects"].([]interface{}))
+		description := groupMapping["description"].(string)
 		upsertGroupMapping := wiz.SAMLGroupDetailsInput{
 			ProviderGroupID: providerGroupID,
 			Role:            role,
 			Projects:        projects,
+			Description:     description,
 		}
 		upsertGroupMappings = append(upsertGroupMappings, upsertGroupMapping)
 	}
@@ -393,6 +403,7 @@ func querySAMLGroupMappings(ctx context.Context, m interface{}, samlIdpID string
 			  projects {
 				id
 			  }
+			  description
 			}
 	    }
 	}`

--- a/internal/provider/resource_saml_group_mapping.go
+++ b/internal/provider/resource_saml_group_mapping.go
@@ -80,9 +80,9 @@ func resourceWizSAMLGroupMapping() *schema.Resource {
 							},
 						},
 						"description": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							Description:  "Group Mapping description",
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Group Mapping description",
 						},
 					},
 				},

--- a/internal/wiz/structs.go
+++ b/internal/wiz/structs.go
@@ -245,11 +245,11 @@ type SAMLGroupMappingCreateInput struct {
 }
 
 // SAMLGroupDetailsInput struct
-// Incomplete because 'description' field is missing as in the schema
 type SAMLGroupDetailsInput struct {
 	ProviderGroupID string   `json:"providerGroupId"`
 	Role            string   `json:"role"`
 	Projects        []string `json:"projects"`
+	Description     string   `json:"description"`
 }
 
 // ModifySAMLGroupMappingPatch struct
@@ -284,6 +284,7 @@ type SAMLGroupMapping struct {
 	Projects        []Project `json:"projects"`
 	ProviderGroupID string    `json:"providerGroupId"`
 	Role            UserRole  `json:"role"`
+	Description     string    `json:"description"`
 }
 
 // DeleteSAMLIdentityProviderInput struct


### PR DESCRIPTION
This PR adds support for the "description" field of Wiz SAML group mapping resource.

Output of acceptance tests:

```
terraform-provider-wiz % TF_ACC=1 go test ./internal/acceptance/... -v -run='TestAccResourceWizSAMLGroupMapping_ba
sic'
=== RUN   TestAccResourceWizSAMLGroupMapping_basic
2025/01/21 12:06:59 [DEBUG] POST https://auth.app.wiz.io/oauth/token
2025/01/21 12:07:00 [DEBUG] POST https://auth.app.wiz.io/oauth/token
2025/01/21 12:07:01 [DEBUG] POST https://api.eu7.app.wiz.io/graphql
2025/01/21 12:07:01 [DEBUG] POST https://api.eu7.app.wiz.io/graphql
2025/01/21 12:07:01 [DEBUG] POST https://api.eu7.app.wiz.io/graphql
2025/01/21 12:07:01 [DEBUG] POST https://api.eu7.app.wiz.io/graphql
2025/01/21 12:07:01 [DEBUG] POST https://api.eu7.app.wiz.io/graphql
2025/01/21 12:07:01 [DEBUG] POST https://api.eu7.app.wiz.io/graphql
2025/01/21 12:07:01 [DEBUG] POST https://api.eu7.app.wiz.io/graphql
2025/01/21 12:07:02 [DEBUG] POST https://api.eu7.app.wiz.io/graphql
2025/01/21 12:07:02 [DEBUG] POST https://api.eu7.app.wiz.io/graphql
2025/01/21 12:07:02 [DEBUG] POST https://api.eu7.app.wiz.io/graphql
2025/01/21 12:07:02 [DEBUG] POST https://api.eu7.app.wiz.io/graphql
2025/01/21 12:07:02 [DEBUG] POST https://api.eu7.app.wiz.io/graphql
2025/01/21 12:07:02 [DEBUG] POST https://api.eu7.app.wiz.io/graphql
2025/01/21 12:07:03 [DEBUG] POST https://api.eu7.app.wiz.io/graphql
2025/01/21 12:07:03 [DEBUG] POST https://api.eu7.app.wiz.io/graphql
2025/01/21 12:07:03 [DEBUG] POST https://api.eu7.app.wiz.io/graphql
2025/01/21 12:07:03 [DEBUG] POST https://api.eu7.app.wiz.io/graphql
2025/01/21 12:07:03 [DEBUG] POST https://api.eu7.app.wiz.io/graphql
2025/01/21 12:07:03 [DEBUG] POST https://api.eu7.app.wiz.io/graphql
2025/01/21 12:07:03 [DEBUG] POST https://api.eu7.app.wiz.io/graphql
2025/01/21 12:07:03 [DEBUG] POST https://api.eu7.app.wiz.io/graphql
2025/01/21 12:07:04 [DEBUG] POST https://api.eu7.app.wiz.io/graphql
2025/01/21 12:07:04 [DEBUG] POST https://api.eu7.app.wiz.io/graphql
2025/01/21 12:07:04 [DEBUG] POST https://auth.app.wiz.io/oauth/token
2025/01/21 12:07:06 [DEBUG] POST https://auth.app.wiz.io/oauth/token
2025/01/21 12:07:06 [DEBUG] POST https://api.eu7.app.wiz.io/graphql
2025/01/21 12:07:07 [DEBUG] POST https://api.eu7.app.wiz.io/graphql
2025/01/21 12:07:07 [DEBUG] POST https://api.eu7.app.wiz.io/graphql
2025/01/21 12:07:07 [DEBUG] POST https://api.eu7.app.wiz.io/graphql
2025/01/21 12:07:07 [DEBUG] POST https://api.eu7.app.wiz.io/graphql
2025/01/21 12:07:07 [DEBUG] POST https://api.eu7.app.wiz.io/graphql
2025/01/21 12:07:07 [DEBUG] POST https://api.eu7.app.wiz.io/graphql
2025/01/21 12:07:07 [DEBUG] POST https://api.eu7.app.wiz.io/graphql
2025/01/21 12:07:07 [DEBUG] POST https://api.eu7.app.wiz.io/graphql
2025/01/21 12:07:08 [DEBUG] POST https://api.eu7.app.wiz.io/graphql
2025/01/21 12:07:08 [DEBUG] POST https://api.eu7.app.wiz.io/graphql
2025/01/21 12:07:08 [DEBUG] POST https://auth.app.wiz.io/oauth/token
2025/01/21 12:07:09 [DEBUG] POST https://auth.app.wiz.io/oauth/token
2025/01/21 12:07:10 [DEBUG] POST https://api.eu7.app.wiz.io/graphql
--- PASS: TestAccResourceWizSAMLGroupMapping_basic (12.81s)
PASS
ok      wiz.io/hashicorp/terraform-provider-wiz/internal/acceptance     13.300s
```